### PR TITLE
Split jobs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,18 +14,25 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'yarn'
-    - run: yarn install
-    - run: yarn build
-    - run: yarn test
+    - name: yarn install and build
+      run: |
+        yarn install
+        yarn build
+        
+  test:
+
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-2016]
+        node-version: [12.x, 14.x, 16.x]
+        
+    steps:
+    - uses: actions/checkout@v2
+    - name: yarn install and test
+      run: |
+        yarn install
+        yarn test


### PR DESCRIPTION
Its a lot nicer and clearer to have build and test as two separate jobs. We're not sure yet if there's any sort of artifacts that need to be passed between them.